### PR TITLE
Switch hex2bin to objcopy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: test.ihx
-	hex2bin -e bin test.ihx
+	objcopy -Iihex -Obinary test.ihx test.bin
 	python binpac8x.py test.bin
 	packihx test.ihx > test.hex
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 helloworld: helloworld.ihx
-	hex2bin -e bin helloworld.ihx
+	objcopy -Iihex -Obinary helloworld.ihx helloworld.bin
 	python binpac8x.py helloworld.bin
 	#packihx helloworld.ihx > helloworld.hex
 


### PR DESCRIPTION
Had some trouble with the current version of hex2bin outputting the wrong results. After some searching I found that objcopy worked just the same.